### PR TITLE
prepare v0.2.0, bump tower@v0.5.2, tokio@v1.44.2, quiet warnings, minimize tokio features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-actor"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A `tower` middleware that creates a `Service` by passing messages to an actor."
@@ -13,7 +13,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tower = "0.4"
+tower = "0.5.2"
 tokio = { version = "1.22", features = ["full", "tracing"] }
 tracing = "0.1"
 tokio-util = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ tokio-util = "0.7"
 futures = "0.3"
 pin-project = "1.0.12"
 thiserror = "1.0.40"
+
+[dev-dependencies]
+tokio = { version = "1.22", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)', 'cfg(fuzzing)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 
 [dependencies]
 tower = "0.5.2"
-tokio = { version = "1.22", features = ["rt", "tracing"] }
+tokio = { version = "1.44.2", features = ["rt", "tracing"] }
 tracing = "0.1"
 tokio-util = "0.7"
 futures = "0.3"
@@ -25,4 +25,4 @@ pin-project = "1.0.12"
 thiserror = "1.0.40"
 
 [dev-dependencies]
-tokio = { version = "1.22", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,12 @@ readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)', 'cfg(fuzzing)'] }
+
 [dependencies]
 tower = "0.5.2"
-tokio = { version = "1.22", features = ["full", "tracing"] }
+tokio = { version = "1.22", features = ["rt", "tracing"] }
 tracing = "0.1"
 tokio-util = "0.7"
 futures = "0.3"


### PR DESCRIPTION
Bumps tower to v0.5.2 (related to https://github.com/penumbra-zone/penumbra/pull/5055).

Bumps tonic to v1.44.2 in response to https://rustsec.org/advisories/RUSTSEC-2025-0023.

Also reduces the active tokio features to the actual used set `rt` and `trace`. Also quiets the "unexpected cfgs" lint introduced in Rust 1.80. See https://blog.rust-lang.org/2024/05/06/check-cfg.html#expecting-custom-cfgs